### PR TITLE
Fixed typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ plugins: [
     options: {
       aws: {
         accessKeyId: 'youraccesskeyhere',
-        secretAccessKeyId: 'hunter2',
+        secretAccessKey: 'hunter2',
       },
       buckets: ['your-s3-bucket.com'],
     },


### PR DESCRIPTION
Without this commit we would get a validation error when using the provided example:

```
plugins: [
  {
    resolve: 'gatsby-source-s3',
    options: {
      aws: {
        accessKeyId: 'youraccesskeyhere',
        secretAccessKeyId: 'hunter2',
      },
      buckets: ['your-s3-bucket.com'],
    },
  },
];
```

![image](https://user-images.githubusercontent.com/20717348/39550834-8ae75750-4e17-11e8-9f1e-242f7b972f86.png)

Which wouldn't make it passed the build phase