### PR TITLE
Changed install example to avoid unnecessary error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Source plugin for pulling in S3 data from AWS for further processing via Gatsby/
 ## Install
 
 ```bash
-npm install gatsby-source-s3 --save-dev
+npm install gatsby-source-s3 --save
 ```
 
 ## How to use


### PR DESCRIPTION
The example on the readme shows to install like this:

```
npm install gatsby-source-s3 --save-dev
```

This is fine and gatsby apps work fine when installing to the dev dependencies. 

However when trying to ```gatsby build``` on a different platform (I used Netlify to benefit from the CMS management tooling it provides **for gatsby projects**) it seems like it cannot be found when being used inside gatsby-config.js, as shown in the screenshot below:

![gatsbysources3](https://user-images.githubusercontent.com/20717348/39674815-84396a82-5106-11e8-9782-3c3b4cc23761.JPG)

## Installing as a dependency solves the problem and benefits all platforms:

```
npm install gatsby-source-s3 --save
```

