### PR TITLE
Make secret & access key optional to enable instance roles

### DIFF
--- a/src/plugin-options.js
+++ b/src/plugin-options.js
@@ -4,8 +4,8 @@ export const schema = yup.object().shape({
   aws: yup
     .object()
     .shape({
-      accessKeyId: yup.string().required(),
-      secretAccessKey: yup.string().required(),
+      accessKeyId: yup.string(),
+      secretAccessKey: yup.string(),
       region: yup.string(),
     })
     .default(() => ({


### PR DESCRIPTION
By making the access key id and secrets optional, the AWS SDK is able to take advantage of instance profiles and any access that the instance has.   This removes the need to explicitly track key information in the config or environment. 

This should also allow the SDK to utilize the local AWS cli credential cache.