### PR TITLE
Update URL template to include Region value

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -24,6 +24,7 @@ export async function sourceNodes(
   );
 
   const buckets = await listObjects(bucketsConfig, awsConfig);
+  const region = awsConfig.region;
 
   await Promise.all(
     buckets.map(({ Contents, ...rest }, index) => {
@@ -33,7 +34,7 @@ export async function sourceNodes(
           const node = {
             ...rest,
             ...content,
-            Url: `https://s3.amazonaws.com/${rest.Name}/${Key}`,
+            Url: `https://s3.${region ? `${region}.` : ''}amazonaws.com/${rest.Name}/${Key}`,
             id: `s3-${Key}`,
             children: [],
             parent: '__SOURCE__',

--- a/src/plugin-options.js
+++ b/src/plugin-options.js
@@ -4,8 +4,8 @@ export const schema = yup.object().shape({
   aws: yup
     .object()
     .shape({
-      accessKeyId: yup.string().required(),
-      secretAccessKey: yup.string().required(),
+      accessKeyId: yup.string(),
+      secretAccessKey: yup.string(),
       region: yup.string(),
     })
     .default(() => ({


### PR DESCRIPTION
In the current Url setup, I was getting a `PermanentRedirect` error when trying to access assets within my bucket, the specified endpoint was incorrect.
Adding the `region` value to the Url fixed this and allowed me access