### PR TITLE
Document support for sessionToken/AWS_SESSION_TOKEN explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ plugins: [
       aws: {
         accessKeyId: 'youraccesskeyhere',
         secretAccessKey: 'hunter2',
+        sessionToken: 'yoursessiontokenhere', // optional session token
       },
       buckets: ['your-s3-bucket-name'],
     },

--- a/src/plugin-options.js
+++ b/src/plugin-options.js
@@ -6,11 +6,13 @@ export const schema = yup.object().shape({
     .shape({
       accessKeyId: yup.string().required(),
       secretAccessKey: yup.string().required(),
+      sessionToken: yup.string(),
       region: yup.string(),
     })
     .default(() => ({
       accessKeyId: process.env.AWS_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+      sessionToken: process.env.AWS_SESSION_TOKEN,
       region: process.env.AWS_REGION,
     })),
   buckets: yup.array().required(),


### PR DESCRIPTION
When using federated identities in AWS, short-lived sessions require the `sessionToken` (or the corresponding `AWS_SESSION_TOKEN` environment variable) in addition to the access key and secret. Even though `gatsby-source-s3` honors the parameter if provided via the plugin options, it is not explicitly documented anywhere.

This PR explicitly lists the parameter in the options schema, and mentions it in the `README.md`