### PR TITLE
Add endpoint configuration to support custom URLs.

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -11,13 +11,9 @@ const createContentDigest = obj =>
     .digest('hex');
 
 const isImage = object => /\.(jpe?g|png|webp|tiff?)$/i.test(object);
-const getBucketName = () => {};
 
-export async function sourceNodes(
-  { boundActionCreators, store, cache },
-  pluginOptions
-) {
-  const { createNode, touchNode } = boundActionCreators;
+export async function sourceNodes({ actions, store, cache }, pluginOptions) {
+  const { createNode, touchNode } = actions;
 
   const { aws: awsConfig, buckets: bucketsConfig } = await schema.validate(
     pluginOptions
@@ -34,7 +30,11 @@ export async function sourceNodes(
           const node = {
             ...rest,
             ...content,
-            Url: `https://s3.${region ? `${region}.` : ''}amazonaws.com/${rest.Name}/${Key}`,
+            Url: awsConfig.endpoint
+              ? `${awsConfig.endpoint.replace(/\/$/, '')}/${rest.Name}/${Key}`
+              : `https://s3.${region ? `${region}.` : ''}amazonaws.com/${
+                  rest.Name
+                }/${Key}`,
             id: `s3-${Key}`,
             children: [],
             parent: '__SOURCE__',

--- a/src/plugin-options.js
+++ b/src/plugin-options.js
@@ -7,12 +7,14 @@ export const schema = yup.object().shape({
       accessKeyId: yup.string(),
       secretAccessKey: yup.string(),
       sessionToken: yup.string(),
+      endpoint: yup.string(),
       region: yup.string(),
     })
     .default(() => ({
       accessKeyId: process.env.AWS_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
       sessionToken: process.env.AWS_SESSION_TOKEN,
+      endpoint: process.env.AWS_DOMAIN,
       region: process.env.AWS_REGION,
     })),
   buckets: yup.array().required(),


### PR DESCRIPTION
This change allows for different endpoint configurations than Amazons default `s3.[region].amazonaws.com`. This is useful for custom DNS configurations or when using other vendors supporting the S3 interface.